### PR TITLE
Added Permission for csinodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ data "aws_iam_role" "kubernetes_worker_node" {
 
 module "kubernetes_dashboard" {
   source = "cookielab/cluster-autoscaler-aws/kubernetes"
-  version = "0.9.0"
+  version = "0.10.0"
 
   aws_iam_role_for_policy = data.aws_iam_role.kubernetes_worker_node.name
 
@@ -28,6 +28,6 @@ module "kubernetes_dashboard" {
     "k8s.io/cluster-autoscaler/${var.kubernetes_cluster_name}",
   ]
 
-  kubernetes_deployment_image_tag = "v1.14.7" # v1.14.x is for kubernetes 1.14.x
+  kubernetes_deployment_image_tag = "v1.16.0" # v1.16.0 is for kubernetes 1.16.x
 }
 ```

--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ resource "kubernetes_cluster_role" "cluster_autoscaler" {
 
   rule {
     api_groups = ["storage.k8s.io"]
-    resources = ["storageclasses"]
+    resources = ["storageclasses","csinodes"]
     verbs = ["watch", "list", "get"]
   }
 
@@ -77,6 +77,15 @@ resource "kubernetes_cluster_role" "cluster_autoscaler" {
     api_groups = ["batch", "extensions"]
     resources = ["jobs"]
     verbs = ["get", "list", "watch", "patch"]
+  }
+
+  dynamic "rule" {
+    for_each = var.additional_kubernetes_cluster_roles
+    content {
+      api_groups = rule.value.api_groups
+      resources = rule.value.resources
+      verbs = rule.value.verbs
+    }
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -73,3 +73,9 @@ variable "aws_iam_role_for_policy" {
   default = null
   description = "AWS IAM Role name for attaching AWS IAM policy."
 }
+
+variable "additional_kubernetes_cluster_roles" {
+  type = list
+  default = []
+  description = "Additional rules to append to Kubernetes cluster roles."
+}


### PR DESCRIPTION
**In Kubernetes 1.16.8 - Logs give following error**

E0618 17:14:01.428766       1 reflector.go:123] k8s.io/client-go/informers/factory.go:134: Failed to list *v1beta1.CSINode: csinodes.storage.k8s.io is forbidden: User "system:serviceaccount:kube-system:cluster-autoscaler" cannot list resource "csinodes" in API group "storage.k8s.io" at the cluster scope

Solved by adding permission to:
```terraform
  rule {
    api_groups = ["storage.k8s.io"]
    resources = ["storageclasses","csinodes"]
    verbs = ["watch", "list", "get"]
  }
```

Also added dynamic block for permission problems that can occur in the future.
_main.tf - resource "kubernetes_cluster_role" "cluster_autoscaler"_
```terraform
  dynamic "rule" {
    for_each = var.additional_kubernetes_cluster_roles
    content {
      api_groups = rule.value.api_groups
      resources = rule.value.resources
      verbs = rule.value.verbs
    }
  }
```
variables.tf
```terraform
variable "additional_kubernetes_cluster_roles" {
  type = list
  default = []
  description = "Additional rules to append to Kubernetes cluster roles."
}
```