### PR TITLE
Allow custom annotations

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -157,6 +157,7 @@ resource "kubernetes_deployment" "cluster_autoscaler" {
     template {
       metadata {
         labels = local.kubernetes_deployment_labels
+        annotations = var.kubernetes_deployment_annotations
       }
 
       spec {

--- a/variables.tf
+++ b/variables.tf
@@ -73,3 +73,9 @@ variable "aws_iam_role_for_policy" {
   default = null
   description = "AWS IAM Role name for attaching AWS IAM policy."
 }
+
+variable "kubernetes_deployment_annotations" {
+  type = map(string)
+  default = {}
+  description = "Annotations for pod template"
+}


### PR DESCRIPTION
The use case behind this is to allow for the "iam.amazonaws.com/role" annotation, so that kube2iam can assign the correct role to the pod.