### PR TITLE
Add permission for apigroup storage.k8s.io csinodes resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ resource "kubernetes_cluster_role" "cluster_autoscaler" {
 
   rule {
     api_groups = ["storage.k8s.io"]
-    resources = ["storageclasses"]
+    resources = ["storageclasses","csinodes"]
     verbs = ["watch", "list", "get"]
   }
 


### PR DESCRIPTION
This is a change required for cluster-autoscaler >= 1.16
It can be seen in the official docs: https://github.com/kubernetes/autoscaler/pull/2404/files